### PR TITLE
Fix: Correct action compute in parquet file

### DIFF
--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -902,10 +902,10 @@ class Stats(BaseModel):
         # We want .tolist() to yield [[[mean_r, mean_g, mean_b]]] and not [mean_r, mean_g, mean_b]
         # Reshape to have the same shape as the mean and std
         # This makes it easier to normalize the imags
-        self.mean = self.mean.reshape(3, 1, 1) / 255
-        self.std = self.std.reshape(3, 1, 1) / 255
-        self.min = self.min.reshape(3, 1, 1) / 255
-        self.max = self.max.reshape(3, 1, 1) / 255
+        self.mean = self.mean.reshape(3, 1, 1)
+        self.std = self.std.reshape(3, 1, 1)
+        self.min = self.min.reshape(3, 1, 1)
+        self.max = self.max.reshape(3, 1, 1)
 
 
 class StatsModel(BaseModel):

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -557,7 +557,7 @@ class Episode(BaseModel):
             assert step.action is not None, (
                 "The action must be set for each step before saving"
             )
-            episode_data["action"] = step.action.tolist()
+            episode_data["action"].append(step.action.tolist())
 
         # Validate frame dimensions and data type
         height, width = self.steps[0].observation.main_image.shape[:2]

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -902,10 +902,10 @@ class Stats(BaseModel):
         # We want .tolist() to yield [[[mean_r, mean_g, mean_b]]] and not [mean_r, mean_g, mean_b]
         # Reshape to have the same shape as the mean and std
         # This makes it easier to normalize the imags
-        self.mean = self.mean.reshape(3, 1, 1)
-        self.std = self.std.reshape(3, 1, 1)
-        self.min = self.min.reshape(3, 1, 1)
-        self.max = self.max.reshape(3, 1, 1)
+        self.mean = self.mean.reshape(3, 1, 1) / 255
+        self.std = self.std.reshape(3, 1, 1) / 255
+        self.min = self.min.reshape(3, 1, 1) / 255
+        self.max = self.max.reshape(3, 1, 1) / 255
 
 
 class StatsModel(BaseModel):

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -538,7 +538,6 @@ class Episode(BaseModel):
             )
 
         # first_episode_timestamp = self.steps[0].observation.timestamp
-        episode_data["action"] = self.get_delta_joints_position().tolist()
 
         logger.info(f"Number of steps during conversion: {len(self.steps)}")
 
@@ -555,6 +554,10 @@ class Episode(BaseModel):
             episode_data["index"].append(frame_index)
             # TODO: Implement multiple tasks in dataset
             episode_data["task_index"].append(0)
+            assert step.action is not None, (
+                "The action must be set for each step before saving"
+            )
+            episode_data["action"] = step.action.tolist()
 
         # Validate frame dimensions and data type
         height, width = self.steps[0].observation.main_image.shape[:2]


### PR DESCRIPTION
the actions were saved as the delta of joints position in the parquet file.
It was correctly computing while recording in the Episode instance, so I just set it to the correct value.