### PR TITLE
Feat: Add delete episode feature, refacto: use dataset abstraction for HF communication

### DIFF
--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1148,13 +1148,12 @@ class Dataset(BaseModel):
         """
         try:
             # Initialize HF API with token
-            hf_api = HfApi(token=True)
 
             # Try to get username/org ID from token
             username_or_org_id = None
             try:
                 # Get user info from token
-                user_info = hf_api.whoami()
+                user_info = self.HF_API.whoami()
                 username_or_org_id = user_info.get("name")
 
                 if not username_or_org_id:
@@ -1197,7 +1196,7 @@ It's compatible with LeRobot and RLDS.
 
             # Check if repo exists, create if it doesn't
             try:
-                hf_api.repo_info(repo_id=dataset_repo_name, repo_type="dataset")
+                self.HF_API.repo_info(repo_id=dataset_repo_name, repo_type="dataset")
                 logger.info(f"Repository {dataset_repo_name} already exists.")
             except Exception as e:
                 logger.info(

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -854,8 +854,8 @@ class Stats(BaseModel):
             self.square_sum = value**2
             self.count = 1
         else:
-            self.sum += value
-            self.square_sum += value**2
+            self.sum = self.sum + value
+            self.square_sum = self.square_sum + value**2
             self.count += 1
 
     def compute_from_rolling(self):
@@ -899,8 +899,8 @@ class Stats(BaseModel):
             self.square_sum = np.sum(image_norm_32**2, axis=(0, 1))
             self.count = nb_pixels
         else:
-            self.sum += np.sum(image_norm_32, axis=(0, 1))
-            self.square_sum += np.sum(image_norm_32**2, axis=(0, 1))
+            self.sum = self.sum + np.sum(image_norm_32, axis=(0, 1))
+            self.square_sum = self.square_sum + np.sum(image_norm_32**2, axis=(0, 1))
             self.count += nb_pixels
 
     def compute_from_rolling_images(self):

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1061,11 +1061,14 @@ class StatsModel(BaseModel):
 
         # For each column in the parquet file, compute sum, square sum, min and max. Write it in a dictionnary
         # TODO: Check if sum is on the first axis
+        logger.info("Updatting stats before removing episode")
+        logger.info(f"Episode df: {episode_df.head()}")
+
         column_sums = {
             col: {
                 "sum": episode_df[col].sum(axis=0),
-                "max": episode_df[col].max(axis=0),
-                "min": episode_df[col].min(axis=0),
+                "max": episode_df[col].max(axis=2),
+                "min": episode_df[col].min(axis=2),
                 "square_sum": (episode_df[col] ** 2).sum(axis=0),
             }
             for col in episode_df.columns

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1303,8 +1303,9 @@ class Stats(BaseModel):
 
         # Update the rolling sum and square sum
         if self.sum is None or self.square_sum is None:
-            self.sum = value
-            self.square_sum = value**2
+            # We need to copy the value to avoid modifying the original value
+            self.sum = value.copy()
+            self.square_sum = value.copy() ** 2
             self.count = 1
         else:
             self.sum = self.sum + value

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1175,16 +1175,20 @@ class StatsModel(BaseModel):
             video_path = os.path.join(
                 folder_videos_path, camera_folder, f"episode_{episode_index:06d}.mp4"
             )
-            sum_array, square_sum_array, frame_count_array = (
+            sum_array, square_sum_array, nb_pixel = (
                 compute_sum_squaresum_framecount_from_video(video_path)
             )
-
+            assert isinstance(nb_pixel, int), "nb_pixel must be an integer"
+            assert isinstance(sum_array, np.ndarray), "sum_array must be a numpy array"
+            assert isinstance(square_sum_array, np.ndarray), (
+                "square_sum_array must be a numpy array"
+            )
             sum_array = sum_array.astype(np.float32)
             square_sum_array = square_sum_array.astype(np.float32)
 
             logger.info(f"sum_array: {sum_array}")
             logger.info(f"square_sum_array: {square_sum_array}")
-            logger.info(f"frame_count_array: {frame_count_array}")
+            logger.info(f"frame_count_array: {nb_pixel}")
 
             # Update the stats_model
             self.observation_images[camera_folder].sum = (
@@ -1194,7 +1198,7 @@ class StatsModel(BaseModel):
                 self.observation_images[camera_folder].square_sum - square_sum_array
             )
             self.observation_images[camera_folder].count = (
-                self.observation_images[camera_folder].count - frame_count_array[0]
+                self.observation_images[camera_folder].count - nb_pixel
             )
             field_value.count -= nb_steps_deleted_episode
             field_value.mean = field_value.sum / field_value.count

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1606,10 +1606,7 @@ class EpisodesModel(BaseModel):
         episode_index is the index of the episode of the current step.
         """
         # If episode_index is not in the episodes, add it
-        logger.info("Updating episodes")
-        logger.info(f"Episodes: {self.episodes}")
         if episode_index not in [episode.episode_index for episode in self.episodes]:
-            logger.info(f"Adding episode: {episode_index}")
             self.episodes.append(
                 EpisodesFeatures(
                     episode_index=episode_index,
@@ -1617,12 +1614,9 @@ class EpisodesModel(BaseModel):
                     length=1,
                 )
             )
-            logger.info(f"Episodes: {self.episodes}")
         else:
             # Increase the nb frames counter
-            logger.info(f"Updating episode: {episode_index}")
             self.episodes[episode_index].length += 1
-            logger.info(f"Episodes: {self.episodes}")
             # Add the language instruction if it's a new one
             if (
                 str(step.observation.language_instruction)
@@ -1631,7 +1625,6 @@ class EpisodesModel(BaseModel):
                 self.episodes[episode_index].tasks.append(
                     str(step.observation.language_instruction)
                 )
-        logger.info("Episodes update complete")
 
     def to_jsonl(self, meta_folder_path: str) -> None:
         """

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1334,15 +1334,22 @@ class Stats(BaseModel):
 
         # Update the max and min
         if self.max is None:
-            self.max = np.max(image_norm_32, axis=(0, 1))
+            self.max = np.max(image_norm_32, axis=(0, 1)).reshape(3, 1, 1)
         else:
+            image_max_pixel = np.max(image_norm_32, axis=(0, 1)).reshape(3, 1, 1)
             # maximum is the max in each channel
-            self.max = np.maximum(self.max, np.max(image_norm_32, axis=(0, 1)))
+            self.max = np.maximum(self.max, image_max_pixel)
 
         if self.min is None:
-            self.min = np.min(image_norm_32, axis=(0, 1))
+            self.min = np.min(image_norm_32, axis=(0, 1)).reshape(3, 1, 1)
+            # Reshape to have the same shape as the mean and std
+            self.min = self.min.reshape(3, 1, 1)
         else:
-            self.min = np.minimum(self.min, np.min(image_norm_32, axis=(0, 1)))
+            image_min_pixel = np.min(image_norm_32, axis=(0, 1)).reshape(3, 1, 1)
+            # Set the min to the min in each channel
+            self.min = np.minimum(self.min, image_min_pixel)
+            # Reshape to have the same shape as the mean and std
+            self.min = self.min.reshape(3, 1, 1)
 
         # Update the rolling sum and square sum
         nb_pixels = image_norm_32.shape[0] * image_norm_32.shape[1]
@@ -1370,10 +1377,8 @@ class Stats(BaseModel):
         # For the first episode the shape is (3,)
         # For the next ones the shape is (3,1,3)
         # We keep min and max of the first episode only
-        if self.min.shape == (3,):
-            self.min = self.min.reshape(3, 1, 1)
-        if self.max.shape == (3,):
-            self.max = self.max.reshape(3, 1, 1)
+        self.min = self.min.reshape(3, 1, 1)
+        self.max = self.max.reshape(3, 1, 1)
 
 
 class StatsModel(BaseModel):

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -771,25 +771,8 @@ class Dataset(BaseModel):
             else f"episode_{episode_id:06d}.{self.data_file_extension}"
         )
 
-    def push_to_hub(self):
-        """Reupload the dataset folder to HuggingFace"""
-        username_or_orgid = get_hf_username_or_orgid()
-        if username_or_orgid is None:
-            logger.warning(
-                "No HuggingFace token found. Please add a token in the Admin page.",
-            )
-            return
-
-        if self.episode_format == "lerobot_v2" and self.check_repo_exists(self.repo_id):
-            upload_folder(
-                folder_path=self.folder_full_path,
-                repo_id=self.repo_id,
-                repo_type="dataset",
-                token=True,
-            )
-
     def sync_local_to_hub(self):
-        # Reupload the dataset folder to HuggingFace
+        """Reupload the dataset folder to HuggingFace"""
         username_or_orgid = get_hf_username_or_orgid()
         if username_or_orgid is None:
             logger.warning(
@@ -1135,15 +1118,11 @@ class Dataset(BaseModel):
 
         return np.mean(episode_fps)
 
-    def push_dataset_to_hub(
-        self, dataset_path: str, dataset_name: str, branch_path: str | None = "2.0"
-    ):
+    def push_dataset_to_hub(self, branch_path: str | None = "2.0"):
         """
-        Push a dataset to the Hugging Face Hub.
+        Push the dataset to the Hugging Face Hub.
 
         Args:
-            dataset_path (str): Path to the dataset folder
-            dataset_name (str): Name of the dataset
             branch_path (str, optional): Additional branch to push to besides main
         """
         try:
@@ -1168,7 +1147,7 @@ class Dataset(BaseModel):
                 return
 
             # Create README if it doesn't exist
-            readme_path = os.path.join(dataset_path, "README.md")
+            readme_path = os.path.join(self.folder_full_path, "README.md")
             if not os.path.exists(readme_path):
                 with open(readme_path, "w") as readme_file:
                     readme_file.write(f"""
@@ -1181,7 +1160,7 @@ task_categories:
 - robotics                                                   
 ---
 
-# {dataset_name}
+# {self.dataset_name}
 
 **This dataset was generated using a [phospho dev kit](https://robots.phospho.ai).**
 
@@ -1191,7 +1170,7 @@ It's compatible with LeRobot and RLDS.
 """)
 
             # Construct full repo name
-            dataset_repo_name = f"{username_or_org_id}/{dataset_name}"
+            dataset_repo_name = f"{username_or_org_id}/{self.dataset_name}"
             create_2_0_branch = False
 
             # Check if repo exists, create if it doesn't
@@ -1216,7 +1195,7 @@ It's compatible with LeRobot and RLDS.
                 f"Pushing the dataset to the main branch in repository {dataset_repo_name}"
             )
             upload_folder(
-                folder_path=dataset_path,
+                folder_path=self.folder_full_path,
                 repo_id=dataset_repo_name,
                 repo_type="dataset",
                 token=True,
@@ -1239,7 +1218,7 @@ It's compatible with LeRobot and RLDS.
                         f"Pushing the dataset to the branch v2.0 in repository {dataset_repo_name}"
                     )
                     upload_folder(
-                        folder_path=dataset_path,
+                        folder_path=self.folder_full_path,
                         repo_id=dataset_repo_name,
                         repo_type="dataset",
                         token=True,
@@ -1267,7 +1246,7 @@ It's compatible with LeRobot and RLDS.
                     # Push to specified branch
                     logger.info(f"Pushing the dataset to branch {branch_path}")
                     upload_folder(
-                        folder_path=dataset_path,
+                        folder_path=self.folder_full_path,
                         repo_id=dataset_repo_name,
                         repo_type="dataset",
                         token=True,

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1594,43 +1594,49 @@ class StatsModel(BaseModel):
     ) -> None:
         """
         Update the stats for images.
+
+        For every camera, we need to delete the episode_{episode_index:06d}.mp4 file.
+
+        We update the sum, square_sum, and count for each camera.
         """
-        cameras_folder = os.listdir(folder_videos_path)
-        for camera_folder in cameras_folder:
+
+        cameras_folders = os.listdir(folder_videos_path)
+        for camera_name in cameras_folders:
             # Create the path of the video episode_{episode_index:06d}.mp4
             video_path = os.path.join(
                 folder_videos_path,
-                camera_folder,
+                camera_name,  # eg: observation.images.main
                 f"episode_{episode_to_delete_index:06d}.mp4",
             )
             sum_array, square_sum_array, nb_pixel = (
                 compute_sum_squaresum_framecount_from_video(video_path)
             )
+
             sum_array = sum_array.astype(np.float32)
             square_sum_array = square_sum_array.astype(np.float32)
 
             # Update the stats_model for sum square_sum and count
-            self.observation_images[camera_folder].sum = (
-                self.observation_images[camera_folder].sum - sum_array
+            self.observation_images[camera_name].sum = (
+                self.observation_images[camera_name].sum - sum_array
             )
-            self.observation_images[camera_folder].square_sum = (
-                self.observation_images[camera_folder].square_sum - square_sum_array
+            self.observation_images[camera_name].square_sum = (
+                self.observation_images[camera_name].square_sum - square_sum_array
             )
-            self.observation_images[camera_folder].count = (
-                self.observation_images[camera_folder].count - nb_pixel
+            self.observation_images[camera_name].count = (
+                self.observation_images[camera_name].count - nb_pixel
             )
             # Update the stats_model for mean and std
             if (
-                self.observation_images[camera_folder].sum is not None
-                and self.observation_images[camera_folder].count
+                self.observation_images[camera_name].sum is not None
+                and self.observation_images[camera_name].count
             ):
                 mean_val = (
-                    np.array(self.observation_images[camera_folder].sum)
-                    / self.observation_images[camera_folder].count
+                    np.array(self.observation_images[camera_name].sum)
+                    / self.observation_images[camera_name].count
                 )
-                self.observation_images[camera_folder].mean = mean_val
-                self.observation_images[camera_folder].square_sum = (
-                    self.observation_images[camera_folder].square_sum
+                self.observation_images[camera_name].mean = mean_val
+                self.observation_images[camera_name].square_sum = (
+                    self.observation_images[camera_name].square_sum
                     - np.square(mean_val)
                 )
 

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1107,9 +1107,10 @@ class StatsModel(BaseModel):
         logger.info(f"Column sums: {column_sums}")
         # Update stats for each field in the StatsModel
         for field_name, field in StatsModel.model_fields.items():
-            # task_index is not updated since we do not support multiple tasks
+            # TODO task_index is not updated since we do not support multiple tasks
+            logger.warning(f"Field name: {field_name}")
             # observation_images has a special treatment
-            if field_name in ["task_index", "observation_images"]:
+            if field_name in ["observation_images"]:
                 continue
             logger.info(f"Updating field {field_name}")
             # Get the field value from the instance

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -965,7 +965,7 @@ class StatsModel(BaseModel):
 
             # Create a temporary dictionary for observation_images
             observation_images = {}
-            for key in list(stats_dict.keys()):
+            for key in stats_dict.keys():
                 if "images" in key:
                     observation_images[key] = Stats(**stats_dict.pop(key))
 

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -555,42 +555,6 @@ class Episode(BaseModel):
             index=episode_data["index"],
         )
 
-    def get_delta_joints_position(self) -> np.ndarray:
-        """
-        Return the delta joints position between each step
-        """
-
-        deltas_joints_position = np.diff(
-            np.array([step.observation.joints_position for step in self.steps]),
-            axis=0,
-        )
-
-        deltas_joints_position = np.vstack(
-            [deltas_joints_position, np.zeros_like(deltas_joints_position[0])]
-        )
-
-        return deltas_joints_position
-
-    def get_fps(self) -> float:
-        """
-        Return the average FPS of the episode
-        """
-        # Calculate FPS for each episode
-
-        timestamps = np.array([step.observation.timestamp for step in self.steps])
-        if (
-            len(timestamps) > 1
-        ):  # Ensure we have at least 2 timestamps to calculate diff
-            fps = 1 / np.mean(np.diff(timestamps))
-
-        return fps
-
-    def get_episode_chunk(self) -> int:
-        """
-        Return the episode chunk
-        """
-        raise NotImplementedError
-
     def get_frames_main_camera(self) -> List[np.ndarray]:
         """
         Return the frames of the main camera

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1112,16 +1112,20 @@ class StatsModel(BaseModel):
                     field_value.min is not None
                     and column_sums[field_name]["min"] is not None
                 ):
+                    logger.success(f"Field value min before: {field_value.min}")
                     field_value.min = np.minimum(
                         field_value.min, column_sums[field_name]["min"]
                     )
+                    logger.success(f"Field value min after: {field_value.min}")
                 if (
                     field_value.max is not None
                     and column_sums[field_name]["max"] is not None
                 ):
+                    logger.success(f"Field value max before: {field_value.max}")
                     field_value.max = np.maximum(
                         field_value.max, column_sums[field_name]["max"]
                     )
+                    logger.success(f"Field value max after: {field_value.max}")
 
                 # Update count
                 field_value.count -= nb_steps_deleted_episode

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -639,17 +639,7 @@ class LeRobotEpisodeModel(BaseModel):
 
 class Dataset(BaseModel):
     """
-    Save a dataset
-
-    ```python
-    dataset.save("robot_dataset.json")
-    ```
-
-    Load dataset
-
-    ```python
-    loaded_dataset = Dataset.load("robot_dataset.json")
-    ```
+    Handle common dataset operations. Useful to manage the dataset.
     """
 
     episodes: List[Episode]
@@ -661,7 +651,10 @@ class Dataset(BaseModel):
     # Full path to the dataset folder
     folder_full_path: str
 
-    def __init__(self, path: str, ROOT_DIR: str = "") -> None:
+    def __init__(self, path: str) -> None:
+        """
+        Load an existing dataset.
+        """
         # Check path format
         path_parts = path.split("/")
         if len(path_parts) < 2 or path_parts[-2] not in ["json", "lerobot_v2"]:
@@ -674,7 +667,7 @@ class Dataset(BaseModel):
             path=path,
             dataset_name=path_parts[-1],
             episode_format=path_parts[-2],
-            full_path=os.path.join(ROOT_DIR, path),
+            full_path=path,
             data_file_extension="json" if path_parts[-2] == "json" else "parquet",
             repo_id=f"{get_hf_username_or_orgid()}/{path_parts[-1]}",
         )

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -878,6 +878,7 @@ class Stats(BaseModel):
         The stats are in dim 3 for RGB.
         We normalize with the number of pixels.
         """
+
         assert image_value.ndim == 3, "Image value must be 3D"
 
         if image_value is None:
@@ -886,8 +887,6 @@ class Stats(BaseModel):
         image_norm_32 = image_value.astype(dtype=np.float32) / 255.0
 
         # Update the max and min
-        # TODO: Is this code ok with the new shape of image_value?
-        # TODO: Check if shape are ok for ex: min or max with shape (3, 1, 3)
         if self.max is None:
             self.max = np.max(image_norm_32, axis=(0, 1))
         else:
@@ -902,23 +901,14 @@ class Stats(BaseModel):
         # Update the rolling sum and square sum
         nb_pixels = image_norm_32.shape[0] * image_norm_32.shape[1]
         # Convert to int32 to avoid overflow when computing the square sum
-        image_uint32 = image_value.astype(dtype=np.int32)
-
         if self.sum is None or self.square_sum is None:
             self.sum = np.sum(image_norm_32, axis=(0, 1))
             self.square_sum = np.sum(image_norm_32**2, axis=(0, 1))
             self.count = nb_pixels
         else:
-            self.sum += np.sum(image_value, axis=(0, 1))
-            self.square_sum += np.sum(image_uint32**2, axis=(0, 1))
+            self.sum += np.sum(image_norm_32, axis=(0, 1))
+            self.square_sum += np.sum(image_norm_32**2, axis=(0, 1))
             self.count += nb_pixels
-
-        # Print a small corner of the image
-        logger.debug(f"Image norm: {image_norm_32[:3, :3]}")
-
-        logger.debug(
-            f"Image stats sum: {self.sum}, square_sum: {self.square_sum}, count: {self.count}"
-        )
 
     def compute_from_rolling_images(self):
         """

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1174,7 +1174,7 @@ class StatsModel(BaseModel):
             video_path = os.path.join(
                 folder_videos_path, camera_folder, f"episode_{episode_index:06d}.mp4"
             )
-            sum_array, square_sum_array, frame_count_array = (
+            sum_array, square_sum_array, nb_pixel = (
                 compute_sum_squaresum_framecount_from_video(video_path)
             )
 
@@ -1183,7 +1183,7 @@ class StatsModel(BaseModel):
 
             logger.info(f"sum_array: {sum_array}")
             logger.info(f"square_sum_array: {square_sum_array}")
-            logger.info(f"frame_count_array: {frame_count_array}")
+            logger.info(f"frame_count_array: {nb_pixel}")
 
             # Update the stats_model
             self.observation_images[camera_folder].sum = (
@@ -1193,7 +1193,7 @@ class StatsModel(BaseModel):
                 self.observation_images[camera_folder].square_sum - square_sum_array
             )
             self.observation_images[camera_folder].count = (
-                self.observation_images[camera_folder].count - frame_count_array[0]
+                self.observation_images[camera_folder].count - nb_pixel[0]
             )
             field_value.count -= nb_steps_deleted_episode
             field_value.mean = field_value.sum / field_value.count

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -870,7 +870,7 @@ class Stats(BaseModel):
         Compute the mean and std from the rolling sum and square sum.
         """
         self.mean = self.sum / self.count
-        self.std = np.sqrt(self.square_sum / self.count - self.mean**2)
+        self.std = np.sqrt(abs(self.square_sum / self.count - self.mean**2))
 
     def update_image(self, image_value: np.ndarray) -> None:
         """
@@ -906,8 +906,8 @@ class Stats(BaseModel):
             self.square_sum = np.sum(image_norm_32**2, axis=(0, 1))
             self.count = nb_pixels
         else:
-            self.sum += np.sum(image_norm_32, axis=(0, 1))
-            self.square_sum += np.sum(image_norm_32**2, axis=(0, 1))
+            self.sum = self.sum + np.sum(image_norm_32, axis=(0, 1))
+            self.square_sum = self.square_sum + np.sum(image_norm_32**2, axis=(0, 1))
             self.count += nb_pixels
 
     def compute_from_rolling_images(self):
@@ -915,7 +915,7 @@ class Stats(BaseModel):
         Compute the mean and std from the rolling sum and square sum for images.
         """
         self.mean = self.sum / self.count
-        self.std = np.sqrt(self.square_sum / self.count - self.mean**2)
+        self.std = np.sqrt(abs(self.square_sum / self.count - self.mean**2))
         # We want .tolist() to yield [[[mean_r, mean_g, mean_b]]] and not [mean_r, mean_g, mean_b]
         # Reshape to have the same shape as the mean and std
         # This makes it easier to normalize the imags

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1004,36 +1004,27 @@ class StatsModel(BaseModel):
         """
         Updates the stats with the given step.
         """
-        logger.info("Updating action stats")
         self.action.update(step.action)
 
-        logger.info("Updating observation state stats")
         # We do not update self.action, as it's updated in .update_previous()
         self.observation_state.update(step.observation.joints_position)
 
-        logger.info("Updating timestamp stats")
         self.timestamp.update(np.array([step.observation.timestamp]))
 
-        logger.info("Updating frame index stats")
         self.frame_index.update(np.array([self.frame_index.count + 1]))
 
-        logger.info("Updating episode index stats")
         self.episode_index.update(np.array([episode_index]))
 
-        logger.info("Updating index stats")
         self.index.update(np.array([self.index.count + 1]))
 
-        logger.info("Updating task index stats")
         # TODO: Implement multiple language instructions
         # This should be the index of the instruction as it's in tasks.jsonl (TasksModel)
         self.task_index.update(np.array([0]))
 
-        logger.info("Processing main image")
         main_image = step.observation.main_image
         (height, width, channel) = main_image.shape
         aspect_ratio: float = width / height
         if aspect_ratio >= 8 / 3:
-            logger.info("Detected stereo image, splitting into left and right")
             # Stereo image detected: split in half
             left_image = main_image[:, : width // 2, :]
             right_image = main_image[:, width // 2 :, :]
@@ -1041,7 +1032,6 @@ class StatsModel(BaseModel):
                 "observation.images.main.left" not in self.observation_images.keys()
                 or "observation.images.main.right" not in self.observation_images.keys()
             ):
-                logger.info("Initializing stereo image stats")
                 # Initialize
                 self.observation_images["observation.images.main.left"] = Stats()
                 self.observation_images["observation.images.main.right"] = Stats()
@@ -1053,35 +1043,24 @@ class StatsModel(BaseModel):
             )
 
         else:
-            logger.info("Processing mono image")
             if "observation.images.main" not in self.observation_images.keys():
-                logger.info("Initializing mono image stats")
                 # Initialize
                 self.observation_images["observation.images.main"] = Stats()
-            logger.info("Updating mono image stats")
             self.observation_images["observation.images.main"].update_image(main_image)
 
-        logger.info(
-            f"Processing {len(step.observation.secondary_images)} secondary images"
-        )
         for image_index, image in enumerate(step.observation.secondary_images):
-            logger.info(f"Processing secondary image {image_index}")
             if (
                 f"observation.images.secondary_{image_index}"
                 not in self.observation_images.keys()
             ):
-                logger.info(f"Initializing secondary image {image_index} stats")
                 # Initialize
                 self.observation_images[
                     f"observation.images.secondary_{image_index}"
                 ] = Stats()
 
-            logger.info(f"Updating secondary image {image_index} stats")
             self.observation_images[
                 f"observation.images.secondary_{image_index}"
             ].update_image(step.observation.secondary_images[image_index])
-
-        logger.info("Stats update complete")
 
     def save(self, meta_folder_path: str) -> None:
         """

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1178,12 +1178,19 @@ class StatsModel(BaseModel):
                 compute_sum_squaresum_framecount_from_video(video_path)
             )
 
+            assert isinstance(sum_array, np.ndarray), "sum_array must be a numpy array"
+            assert isinstance(square_sum_array, np.ndarray), (
+                "square_sum_array must be a numpy array"
+            )
+            assert isinstance(nb_pixel, int), "nb_pixel must be an integer"
             sum_array = sum_array.astype(np.float32)
             square_sum_array = square_sum_array.astype(np.float32)
 
             logger.info(f"sum_array: {sum_array}")
             logger.info(f"square_sum_array: {square_sum_array}")
-            logger.info(f"frame_count_array: {nb_pixel}")
+            logger.info(f"nb_pixel: {nb_pixel}")
+
+            logger.info(f"Old sum: {self.observation_images[camera_folder].sum}")
 
             # Update the stats_model
             self.observation_images[camera_folder].sum = (
@@ -1193,7 +1200,7 @@ class StatsModel(BaseModel):
                 self.observation_images[camera_folder].square_sum - square_sum_array
             )
             self.observation_images[camera_folder].count = (
-                self.observation_images[camera_folder].count - nb_pixel[0]
+                self.observation_images[camera_folder].count - nb_pixel
             )
             field_value.count -= nb_steps_deleted_episode
             field_value.mean = field_value.sum / field_value.count

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -914,9 +914,12 @@ class Stats(BaseModel):
         # This makes it easier to normalize the imags
         self.mean = self.mean.reshape(3, 1, 1)
         self.std = self.std.reshape(3, 1, 1)
-        if self.min.shape != (3, 1, 3):
+        # For the first episode the shape is (3,)
+        # For the next ones the shape is (3,1,3)
+        # We keep min and max of the first episode only
+        if self.min.shape == (3,):
             self.min = self.min.reshape(3, 1, 1)
-        if self.max.shape != (3, 1, 3):
+        if self.max.shape == (3,):
             self.max = self.max.reshape(3, 1, 1)
 
 

--- a/phosphobot/models.py
+++ b/phosphobot/models.py
@@ -1769,7 +1769,7 @@ class InfoModel(BaseModel):
     codebase_version: str = "v2.0"
     total_episodes: int = 0
     total_frames: int = 0
-    total_tasks: int = 0
+    total_tasks: int = 1  # By default, there is 1 task: "None"
     total_videos: int = 0
     total_chunks: int = 1
     chunks_size: int = 1000

--- a/phosphobot/utils.py
+++ b/phosphobot/utils.py
@@ -196,7 +196,9 @@ def get_home_app_path() -> Path:
     return home_path
 
 
-def compute_sum_squaresum_framecount_from_video(video_path: str) -> List[np.ndarray]:
+def compute_sum_squaresum_framecount_from_video(
+    video_path: str,
+) -> List[np.ndarray | int]:
     """
     Process a video file and calculate the sum of RGB values and sum of squares of RGB values for each frame.
     Returns a list of np.ndarray corresponding respectively to the sum of RGB values, sum of squares of RGB values and nb_pixel.
@@ -208,6 +210,7 @@ def compute_sum_squaresum_framecount_from_video(video_path: str) -> List[np.ndar
     if not cap.isOpened():
         raise FileNotFoundError(f"Error: Could not open video at path: {video_path}")
 
+    nb_pixel = 0
     total_sum_rgb = np.zeros(3, dtype=np.uint64)  # To store sum of RGB values
     total_sum_squares = np.zeros(
         3, dtype=np.uint64
@@ -230,9 +233,9 @@ def compute_sum_squaresum_framecount_from_video(video_path: str) -> List[np.ndar
         total_sum_squares += sum_squares
 
         # nb Pixel
-        nb_pixel = frame_rgb.shape[0] * frame_rgb.shape[1]
+        nb_pixel += frame_rgb.shape[0] * frame_rgb.shape[1]
 
     # Release the video capture object
     # TODO: If problem of dimension maybe transposing arrays is needed.
     cap.release()
-    return [total_sum_rgb, total_sum_squares, np.array([nb_pixel])]
+    return [total_sum_rgb, total_sum_squares, nb_pixel]

--- a/phosphobot/utils.py
+++ b/phosphobot/utils.py
@@ -199,7 +199,8 @@ def get_home_app_path() -> Path:
 def compute_sum_squaresum_framecount_from_video(video_path: str) -> List[np.ndarray]:
     """
     Process a video file and calculate the sum of RGB values and sum of squares of RGB values for each frame.
-    Returns a list of np.ndarray corresponding respectively to the sum of RGB values, sum of squares of RGB values and frame count
+    Returns a list of np.ndarray corresponding respectively to the sum of RGB values, sum of squares of RGB values and nb_pixel.
+    We divide by 255.0 RGB values to normalize the values to the range [0, 1].
     """
     # Open the video file
     cap = cv2.VideoCapture(video_path)

--- a/phosphobot/utils.py
+++ b/phosphobot/utils.py
@@ -223,14 +223,15 @@ def compute_sum_squaresum_framecount_from_video(
             break
 
         # Convert the frame from BGR to RGB (OpenCV uses BGR by default)
-        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB) / 255.0
+        logger.info(f"Frame first value {frame_rgb[0, 0]}")
         # Calculate the sum of RGB values for the frame
-        sum_rgb = np.sum(frame_rgb, axis=(0, 1)) / 255.0
+        sum_rgb = np.sum(frame_rgb, axis=(0, 1))
         # Calculate the sum of squares of RGB values for the frame
-        sum_squares = np.sum(frame_rgb**2, axis=(0, 1)) / (255.0**2)
+        sum_squares = np.sum(frame_rgb**2, axis=(0, 1))
         # Accumulate the sums
         # Cannot cast ufunc 'add' output from dtype('float64') to dtype('uint64') with casting rule 'same_kind'
-        total_sum_rgb = total_sum_squares + sum_rgb
+        total_sum_rgb = total_sum_rgb + sum_rgb
         total_sum_squares = total_sum_squares + sum_squares
 
         # nb Pixel

--- a/phosphobot/utils.py
+++ b/phosphobot/utils.py
@@ -270,6 +270,7 @@ def get_field_min_max(df: pd.DataFrame, field_name: str) -> tuple:
     if isinstance(sample_value, (list, np.ndarray)):
         # Check that df[field_name].values is a np.ndarray
         array_values = df[field_name].values
+
         if not isinstance(array_values, np.ndarray):
             raise ValueError(
                 f"Field '{field_name}' values are not stored as a numpy array in the DataFrame"

--- a/phosphobot/utils.py
+++ b/phosphobot/utils.py
@@ -199,7 +199,7 @@ def get_home_app_path() -> Path:
 
 def compute_sum_squaresum_framecount_from_video(
     video_path: str,
-) -> List[np.ndarray | int]:
+) -> Tuple[np.ndarray, np.ndarray, int]:
     """
     Process a video file and calculate the sum of RGB values and sum of squares of RGB values for each frame.
     Returns a list of np.ndarray corresponding respectively to the sum of RGB values, sum of squares of RGB values and nb_pixel.
@@ -240,7 +240,7 @@ def compute_sum_squaresum_framecount_from_video(
     # Release the video capture object
     # TODO: If problem of dimension maybe transposing arrays is needed.
     cap.release()
-    return [total_sum_rgb, total_sum_squares, nb_pixel]
+    return (total_sum_rgb, total_sum_squares, nb_pixel)
 
 
 def get_field_min_max(df: pd.DataFrame, field_name: str) -> tuple:
@@ -252,7 +252,7 @@ def get_field_min_max(df: pd.DataFrame, field_name: str) -> tuple:
 
     Parameters:
         df (pd.DataFrame): DataFrame containing the data.
-        field_name (str): The name of the field/column to compute the min for.
+        field_name (str): The name of the field/column to compute the min,max for.
 
     Returns:
         The minimum value(s) for the specified field.
@@ -269,7 +269,10 @@ def get_field_min_max(df: pd.DataFrame, field_name: str) -> tuple:
     # If the field values are lists or arrays, compute element-wise min, max
     if isinstance(sample_value, (list, np.ndarray)):
         try:
-            array_values = df[field_name].values
+            logger.debug(f"Computing min/max for field: {field_name}")
+            logger.debug(f"Values: {df[field_name].values}")
+            logger.debug(f"Values type: {type(df[field_name].values)}")
+            stacked = np.stack(df[field_name].tolist(), axis=0)
         except Exception as e:
             raise ValueError(
                 "Ensure all entries in the field are lists/arrays of the same length."
@@ -277,7 +280,7 @@ def get_field_min_max(df: pd.DataFrame, field_name: str) -> tuple:
 
         # Compute element-wise minimum along the rows.
         # TODO: Change that
-        return 0, 0
+        return np.min(stacked, axis=0), np.max(stacked, axis=0)
 
     else:
         # Otherwise, assume the field is numeric and return the scalar min.

--- a/phosphobot/utils.py
+++ b/phosphobot/utils.py
@@ -269,16 +269,16 @@ def get_field_min_max(df: pd.DataFrame, field_name: str) -> tuple:
     # If the field values are lists or arrays, compute element-wise min, max
     if isinstance(sample_value, (list, np.ndarray)):
         try:
-            # Convert series of lists/arrays into a 2D NumPy array.
-            # Each row is one entry from the DataFrame.
-            stacked = np.stack(df[field_name].tolist(), axis=0)
+            array_values = df[field_name].values
         except Exception as e:
             raise ValueError(
                 "Ensure all entries in the field are lists/arrays of the same length."
             ) from e
 
         # Compute element-wise minimum along the rows.
-        return (np.min(stacked, axis=0), np.max(stacked, axis=0))
+        # TODO: Change that
+        return 0, 0
+
     else:
         # Otherwise, assume the field is numeric and return the scalar min.
         return (df[field_name].min(), df[field_name].max())

--- a/phosphobot/utils.py
+++ b/phosphobot/utils.py
@@ -211,9 +211,9 @@ def compute_sum_squaresum_framecount_from_video(
         raise FileNotFoundError(f"Error: Could not open video at path: {video_path}")
 
     nb_pixel = 0
-    total_sum_rgb = np.zeros(3, dtype=np.uint64)  # To store sum of RGB values
+    total_sum_rgb = np.zeros(3, dtype=np.float32)  # To store sum of RGB values
     total_sum_squares = np.zeros(
-        3, dtype=np.uint64
+        3, dtype=np.float32
     )  # To store sum of squares of RGB values
     while True:
         # Read a frame from the video
@@ -229,8 +229,9 @@ def compute_sum_squaresum_framecount_from_video(
         # Calculate the sum of squares of RGB values for the frame
         sum_squares = np.sum(frame_rgb**2, axis=(0, 1)) / (255.0**2)
         # Accumulate the sums
-        total_sum_rgb += sum_rgb
-        total_sum_squares += sum_squares
+        # Cannot cast ufunc 'add' output from dtype('float64') to dtype('uint64') with casting rule 'same_kind'
+        total_sum_rgb = total_sum_squares + sum_rgb
+        total_sum_squares = total_sum_squares + sum_squares
 
         # nb Pixel
         nb_pixel += frame_rgb.shape[0] * frame_rgb.shape[1]

--- a/phosphobot/utils.py
+++ b/phosphobot/utils.py
@@ -207,7 +207,6 @@ def compute_sum_squaresum_framecount_from_video(video_path: str) -> List[np.ndar
     if not cap.isOpened():
         raise FileNotFoundError(f"Error: Could not open video at path: {video_path}")
 
-    frame_count = 0
     total_sum_rgb = np.zeros(3, dtype=np.uint64)  # To store sum of RGB values
     total_sum_squares = np.zeros(
         3, dtype=np.uint64
@@ -222,16 +221,17 @@ def compute_sum_squaresum_framecount_from_video(video_path: str) -> List[np.ndar
         # Convert the frame from BGR to RGB (OpenCV uses BGR by default)
         frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         # Calculate the sum of RGB values for the frame
-        sum_rgb = np.sum(frame_rgb, axis=(0, 1))
+        sum_rgb = np.sum(frame_rgb, axis=(0, 1)) / 255.0
         # Calculate the sum of squares of RGB values for the frame
-        sum_squares = np.sum(frame_rgb**2, axis=(0, 1))
+        sum_squares = np.sum(frame_rgb**2, axis=(0, 1)) / (255.0**2)
         # Accumulate the sums
         total_sum_rgb += sum_rgb
         total_sum_squares += sum_squares
 
-        frame_count += 1
+        # nb Pixel
+        nb_pixel = frame_rgb.shape[0] * frame_rgb.shape[1]
 
     # Release the video capture object
     # TODO: If problem of dimension maybe transposing arrays is needed.
     cap.release()
-    return [total_sum_rgb, total_sum_squares, np.array([frame_count])]
+    return [total_sum_rgb, total_sum_squares, np.array([nb_pixel])]

--- a/phosphobot/utils.py
+++ b/phosphobot/utils.py
@@ -224,7 +224,6 @@ def compute_sum_squaresum_framecount_from_video(
 
         # Convert the frame from BGR to RGB (OpenCV uses BGR by default)
         frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB) / 255.0
-        logger.info(f"Frame first value {frame_rgb[0, 0]}")
         # Calculate the sum of RGB values for the frame
         sum_rgb = np.sum(frame_rgb, axis=(0, 1))
         # Calculate the sum of squares of RGB values for the frame

--- a/phosphobot/utils.py
+++ b/phosphobot/utils.py
@@ -268,19 +268,18 @@ def get_field_min_max(df: pd.DataFrame, field_name: str) -> tuple:
 
     # If the field values are lists or arrays, compute element-wise min, max
     if isinstance(sample_value, (list, np.ndarray)):
-        try:
-            logger.debug(f"Computing min/max for field: {field_name}")
-            logger.debug(f"Values: {df[field_name].values}")
-            logger.debug(f"Values type: {type(df[field_name].values)}")
-            stacked = np.stack(df[field_name].tolist(), axis=0)
-        except Exception as e:
+        # Check that df[field_name].values is a np.ndarray
+        array_values = df[field_name].values
+        if not isinstance(array_values, np.ndarray):
             raise ValueError(
-                "Ensure all entries in the field are lists/arrays of the same length."
-            ) from e
-
-        # Compute element-wise minimum along the rows.
-        # TODO: Change that
-        return np.min(stacked, axis=0), np.max(stacked, axis=0)
+                f"Field '{field_name}' values are not stored as a numpy array in the DataFrame"
+            )
+        else:
+            # No overload variant of "vstack" matches argument type "ndarray[Any, Any]"
+            return np.min(np.vstack(array_values), axis=1), np.max(  # type: ignore
+                np.vstack(array_values),  # type: ignore
+                axis=1,
+            )
 
     else:
         # Otherwise, assume the field is numeric and return the scalar min.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "opencv-python>=4.11.0.86",
     "rich>=13.9.4",
     "pandas-stubs>=2.2.2.240807",
+    "huggingface-hub>=0.29.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
I added a method update_before_episode_removal to all meta models. This updates meta files before an episode is deleted from the dataset.
I also added the function compute_sum_squaresum_framecount_from_video, which computes the sum, square sum, and frame count from MP4 videos. This is used to update meta stats.