### PR TITLE
Added hf token handling

### DIFF
--- a/phosphobot/phosphobot/am/gr00t.py
+++ b/phosphobot/phosphobot/am/gr00t.py
@@ -988,7 +988,7 @@ class Gr00tTrainer(BaseTrainer):
         if self.config.model_name is not None:
             # We check if the user has write access to the model-id
             if not HuggingFaceTokenValidator().has_write_access(
-                hf_model_name=self.config.model_name
+                hf_token=os.getenv("HF_TOKEN"), hf_model_name=self.config.model_name
             ):
                 raise ValueError(
                     f"The provided HF token does not have write access to {self.config.model_name}"
@@ -1004,7 +1004,7 @@ class Gr00tTrainer(BaseTrainer):
                     repo_type="dataset",
                     revision=selected_branch,
                     local_dir=str(data_dir),
-                    # token=hf_token,
+                    token=os.getenv("HF_TOKEN"),
                 )
                 DATASET_PATH = Path(dataset_path_as_str)
                 logger.info(
@@ -1069,7 +1069,7 @@ class Gr00tTrainer(BaseTrainer):
             logger.info(f"Uploading model to Hugging Face as {self.config.model_name}")
 
             # Upload using huggingface_hub
-            api = HfApi()
+            api = HfApi(token=os.getenv("HF_TOKEN"))
             files_directory = output_dir
 
             api.create_repo(

--- a/tutorials/00_finetune_gr00t_vla.md
+++ b/tutorials/00_finetune_gr00t_vla.md
@@ -33,10 +33,10 @@ pip install --no-build-isolation flash-attn==2.7.1.post4
 ```
 
 Now, you need to login to Hugging Face to be able to download the datasets.
-Get an access token from [here](https://huggingface.co/settings/tokens) and run:
+Get an access token from [here](https://huggingface.co/settings/tokens) and set it as an environment variable:
 
 ```bash
-huggingface-cli login
+export HF_TOKEN=<your_token>
 ```
 
 Follow the instructions to login.


### PR DESCRIPTION
Fixing the error where the HF API would throw an error if you didn't run `huggingface-cli login` and passing the env variable `HF_TOKEN` if it set instead.