### PR TITLE
fix warnings in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -374,10 +374,9 @@ main() {
     # Common installation steps
     if [[ "$PLATFORM" != "darwin" ]]; then
         echo "Installing phosphobot..."
-        DISTRO_CODENAME="$(lsb_release -sc)"
         curl -fsSL https://europe-west1-apt.pkg.dev/doc/repo-signing-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/phosphobot-archive-keyring.gpg
 
-        echo "deb [signed-by=/usr/share/keyrings/phosphobot-archive-keyring.gpg] https://europe-west1-apt.pkg.dev/projects/portal-385519 phospho-apt ${DISTRO_CODENAME} main" | sudo tee /etc/apt/sources.list.d/phosphobot.list > /dev/null
+        echo "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/phosphobot-archive-keyring.gpg] https://europe-west1-apt.pkg.dev/projects/portal-385519 phospho-apt main" | sudo tee /etc/apt/sources.list.d/phosphobot.list > /dev/null
         sudo apt update
         sudo apt install -y phosphobot
     else


### PR DESCRIPTION
Fixes stray issues of https://github.com/phospho-app/phosphobot/issues/58 by updating the `install.sh` script.

Explicitly listing the supported architecture seems to be the way to avoid users seeing the 
`Notice: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://europe-west1-apt.pkg.dev/projects/portal-385519 phospho-apt InRelease' doesn't support architecture 'i386'` 


The list should include all architectures for which phosphobot provides .deb packages in this repository. I put in `arch=amd64,arm64`.

I removed the distro codename so `phospho-apt ${DISTRO_CODENAME} main` is now just `phospho-apt main`. This resolves warnings like 
`Warning: Skipping acquire of configured file 'plucky/binary-amd64/Packages' as repository 'https://europe-west1-apt.pkg.dev/projects/portal-385519 phospho-apt InRelease' doesn't have the component 'plucky' (component misspelt in sources.list?)` 

