### PR TITLE
Add optional validation dataset for gr00t training

### DIFF
--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -97,13 +97,12 @@ export type TrainingParamsGR00T = {
   learning_rate?: number;
   epochs?: number;
   train_test_split?: number;
-  validation_data_dir?: string | null;
+  validation_dataset_name?: string;
 };
 
 export type TrainingRequest = {
   model_type: "gr00t" | "ACT" | "custom";
   dataset_name: string;
-  validation_dataset_name?: string;
   model_name: string;
   wandb_api_key?: string;
   training_params?: TrainingParamsACT | TrainingParamsGR00T;

--- a/dashboard/src/types.ts
+++ b/dashboard/src/types.ts
@@ -97,11 +97,13 @@ export type TrainingParamsGR00T = {
   learning_rate?: number;
   epochs?: number;
   train_test_split?: number;
+  validation_data_dir?: string | null;
 };
 
 export type TrainingRequest = {
   model_type: "gr00t" | "ACT" | "custom";
   dataset_name: string;
+  validation_dataset_name?: string;
   model_name: string;
   wandb_api_key?: string;
   training_params?: TrainingParamsACT | TrainingParamsGR00T;

--- a/phosphobot/phosphobot/am/base.py
+++ b/phosphobot/phosphobot/am/base.py
@@ -104,6 +104,11 @@ class TrainingParamsGr00T(BaseModel):
         gt=0,
         le=1,
     )
+    validation_dataset_name: str | None = Field(
+        default=None,
+        description="Optional dataset repository ID on Hugging Face to use for validation",
+    )
+
     batch_size: int | None = Field(
         default=None,
         description="Batch size for training, default is 64, decrease it if you get an out of memory error",
@@ -129,7 +134,7 @@ class TrainingParamsGr00T(BaseModel):
 
     validation_data_dir: str | None = Field(
         default=None,
-        description="Optional directory to save the validation dataset to",
+        description="Optional directory to save the validation dataset to. If None, no validation will be done.",
     )
 
     output_dir: str = Field(
@@ -155,10 +160,6 @@ class BaseTrainerConfig(BaseModel):
         description="Dataset repository ID on Hugging Face, should be a public dataset",
     )
 
-    validation_dataset_name: str | None = Field(
-        default=None,
-        description="Optional dataset repository ID on Hugging Face to use for validation",
-    )
     model_name: Optional[str] = Field(
         default=None,
         description="Name of the trained model to upload to Hugging Face, should be in the format phospho-app/<model_name> or <model_name>",
@@ -209,21 +210,6 @@ class TrainingRequest(BaseTrainerConfig):
 
     @field_validator("dataset_name", mode="before")
     def validate_dataset(cls, dataset_name: str) -> str:
-        try:
-            url = f"https://huggingface.co/api/datasets/{dataset_name}/tree/main"
-            response = requests.get(url, timeout=5)
-            if response.status_code != 200:
-                raise ValueError()
-            return dataset_name
-        except Exception:
-            raise ValueError(
-                f"Dataset {dataset_name} is not a valid, public Hugging Face dataset. Please check the URL and try again. Your dataset name should be in the format <username>/<dataset_name>",
-            )
-
-    @field_validator("validation_dataset_name", mode="before")
-    def validate_validation_dataset(cls, dataset_name: str | None) -> str | None:
-        if dataset_name is None:
-            return None
         try:
             url = f"https://huggingface.co/api/datasets/{dataset_name}/tree/main"
             response = requests.get(url, timeout=5)

--- a/phosphobot/phosphobot/am/gr00t.py
+++ b/phosphobot/phosphobot/am/gr00t.py
@@ -139,7 +139,7 @@ class BaseInferenceServer:
                         "status": "error",
                         "error_type": type(e).__name__,
                         "message": str(e),
-                        # omit traceback if you don’t want to expose internals
+                        # omit traceback if you don't want to expose internals
                         "traceback": tb,
                     }
                     self.socket.send(TorchSerializer.to_bytes(error_resp))
@@ -258,7 +258,7 @@ class BaseInferenceClient:
                 raise RuntimeError(f"{et}: {msg}\n\n{tb}")
             return resp.get("result", {})
         else:
-            # legacy: the handler’s own dict
+            # legacy: the handler's own dict
             return resp
 
     def __del__(self):
@@ -738,7 +738,7 @@ class Gr00tN1(ActionModel):
                     image = cv2.cvtColor(rgb_frame, cv2.COLOR_RGB2BGR)
                     # Add a batch dimension (from (240, 320, 3) to (1, 240, 320, 3))
                     converted_array = np.expand_dims(image, axis=0)
-                    # Ensure dtype is uint8 (if it isn’t already)
+                    # Ensure dtype is uint8 (if it isn't already)
                     converted_array = converted_array.astype(np.uint8)
                     image_inputs[f"video.{camera_name}"] = converted_array
 
@@ -916,13 +916,16 @@ async def run_gr00t_training(
         "python",
         f"{gr00t_repo_path}/scripts/gr00t_finetune.py",
         "--dataset-path",
-        str(data_dir),
+        str(data_dir)
     ]
+    
     if validation_data_dir is not None:
         cmd.extend([
             "--validation-dataset-path",
-            str(validation_data_dir),
+            str(validation_data_dir)
         ])
+    
+    # Add remaining arguments
     cmd.extend([
         # Only 1 GPU for now
         # Open an issue for multi-GPU support
@@ -945,8 +948,8 @@ async def run_gr00t_training(
         "--report_to",
         "wandb" if wandb_enabled else "tensorboard",
         "--video_backend",
-        "torchvision_av",
-    ]
+        "torchvision_av"
+    ])
 
     logger.info(f"Starting training with command: {' '.join(cmd)}")
 

--- a/phosphobot/phosphobot/endpoints/training.py
+++ b/phosphobot/phosphobot/endpoints/training.py
@@ -121,6 +121,23 @@ async def start_training(
             detail=f"Failed to download and parse meta/info.json.\n{e}",
         )
 
+    if request.validation_dataset_name:
+        try:
+            info_file_path = api.hf_hub_download(
+                repo_id=request.validation_dataset_name,
+                repo_type="dataset",
+                filename="meta/info.json",
+                force_download=True,
+            )
+            meta_folder_path = os.path.dirname(info_file_path)
+            InfoModel.from_json(meta_folder_path=meta_folder_path)
+        except Exception as e:
+            logger.warning(f"Error accessing validation dataset info: {e}")
+            raise HTTPException(
+                status_code=404,
+                detail=f"Failed to download and parse validation meta/info.json.\n{e}",
+            )
+
     # Send training request to modal API
     async with httpx.AsyncClient(timeout=30) as client:
         response = await client.post(

--- a/phosphobot/phosphobot/endpoints/training.py
+++ b/phosphobot/phosphobot/endpoints/training.py
@@ -2,6 +2,7 @@ import os
 import time
 import asyncio
 import platform
+from typing import cast
 
 from fastapi.responses import PlainTextResponse, StreamingResponse
 import httpx
@@ -9,7 +10,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from huggingface_hub import HfApi
 from loguru import logger
 
-from phosphobot.am.base import TrainingRequest
+from phosphobot.am.base import TrainingRequest, TrainingParamsGr00T
 from phosphobot.models import (
     CustomTrainingRequest,
     StatusResponse,
@@ -120,23 +121,26 @@ async def start_training(
             status_code=404,
             detail=f"Failed to download and parse meta/info.json.\n{e}",
         )
-
-    if request.validation_dataset_name:
-        try:
-            info_file_path = api.hf_hub_download(
-                repo_id=request.validation_dataset_name,
-                repo_type="dataset",
-                filename="meta/info.json",
-                force_download=True,
-            )
-            meta_folder_path = os.path.dirname(info_file_path)
-            InfoModel.from_json(meta_folder_path=meta_folder_path)
-        except Exception as e:
-            logger.warning(f"Error accessing validation dataset info: {e}")
-            raise HTTPException(
-                status_code=404,
-                detail=f"Failed to download and parse validation meta/info.json.\n{e}",
-            )
+    # The check is only done for gr00t models
+    if request.model_type == "gr00t":
+        # We cast the training params to the correct type
+        training_params = cast(TrainingParamsGr00T, request.training_params)
+        if training_params.validation_dataset_name:
+            try:
+                info_file_path = api.hf_hub_download(
+                    repo_id=training_params.validation_dataset_name,
+                    repo_type="dataset",
+                    filename="meta/info.json",
+                    force_download=True,
+                )
+                meta_folder_path = os.path.dirname(info_file_path)
+                InfoModel.from_json(meta_folder_path=meta_folder_path)
+            except Exception as e:
+                logger.warning(f"Error accessing validation dataset info: {e}")
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Failed to download and parse validation meta/info.json.\n{e}",
+                )
 
     # Send training request to modal API
     async with httpx.AsyncClient(timeout=30) as client:
@@ -207,7 +211,7 @@ async def start_custom_training(
         loop = asyncio.get_running_loop()
         reader = asyncio.StreamReader()
         protocol = asyncio.StreamReaderProtocol(reader)
-        # Wrap the master FD as a “read pipe” so .read() becomes non-blocking
+        # Wrap the master FD as a "read pipe" so .read() becomes non-blocking
         await loop.connect_read_pipe(lambda: protocol, os.fdopen(master_fd, "rb"))
     else:
         process = await asyncio.create_subprocess_shell(


### PR DESCRIPTION
## Summary
- extend training config with optional validation dataset fields
- add validation dataset handling in the training endpoint
- download and prepare validation data in `Gr00tTrainer`
- pass validation dataset path to `gr00t_finetune.py`
- update dashboard types

## Testing
- `pytest -q` *(fails: `pytest` not found)*