### PR TITLE
Fix: Bump go2-webrtc-connect to remove dependency issue with `aiortc==1.9.0`

### DIFF
--- a/phosphobot/pyproject.toml
+++ b/phosphobot/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pyrealsense2-macosx>=2.54; platform_system == 'Darwin'",
     "fastparquet>=2024.11.0",
     "httpx[socks]>=0.28.1",
-    "go2-webrtc-connect>=0.1.3",
+    "go2-webrtc-connect>=0.2.0",
     "scapy>=2.6.1",
     "netifaces>=0.11.0",
     "wasmtime>=33.0.0",


### PR DESCRIPTION
Related to : https://github.com/phospho-app/go2_webrtc_connect/releases