### PR TITLE
fix: Adds gripper torque monitoring to leader arm control, lower default max torque threshold

### DIFF
--- a/phosphobot/phosphobot/endpoints/control.py
+++ b/phosphobot/phosphobot/endpoints/control.py
@@ -1330,6 +1330,8 @@ async def get_robot_config(
             name=robot.name,
             config=config,
             gripper_joint_index=robot.GRIPPER_JOINT_INDEX,
+            servo_ids=robot.SERVO_IDS,
+            resolution=robot.RESOLUTION,
         )
 
     raise HTTPException(

--- a/phosphobot/phosphobot/endpoints/control.py
+++ b/phosphobot/phosphobot/endpoints/control.py
@@ -369,7 +369,6 @@ async def move_relative(
                 detail=f"Robot {robot.name} .move_to_initial_position() did not set initial position or orientation: {initial_position=}, {initial_orientation_rad=}",
             )
 
-    logger.info(f"Received relative data: {data}")
     delta_position = np.array([data.x, data.y, data.z])
     delta_orientation_euler_degrees = np.array([data.rx, data.ry, data.rz])
     open = data.open if data.open is not None else None
@@ -397,10 +396,6 @@ async def move_relative(
     # Round to 3 decimals
     target_position = np.round(target_position, 3)
     target_orientation = np.round(target_orientation, 3)
-
-    logger.info(
-        f"Target position: {target_position}. Target orientation: {target_orientation}"
-    )
 
     await move_to_absolute_position(
         query=MoveAbsoluteRequest(

--- a/phosphobot/phosphobot/hardware/base.py
+++ b/phosphobot/phosphobot/hardware/base.py
@@ -1033,6 +1033,7 @@ class BaseManipulator(BaseRobot):
         if not self.is_object_gripped:
             open_command_clipped = np.clip(open_command, 0, 1)
         else:
+            # open_command 0 is closed. We won't close further if the object is already gripped, i.e. we will not send a command < closing_gripper_value
             open_command_clipped = np.clip(open_command, self.closing_gripper_value, 1)
 
         # Only tighten if object is not gripped:

--- a/phosphobot/phosphobot/hardware/base.py
+++ b/phosphobot/phosphobot/hardware/base.py
@@ -339,6 +339,7 @@ class BaseManipulator(BaseRobot):
         try:
             with open(json_filename, "r") as f:
                 data = json.load(f)
+            logger.debug(f"Loaded default config from {json_filename}")
             return BaseRobotConfig(**data)
         except FileNotFoundError:
             if raise_if_none:
@@ -1003,7 +1004,7 @@ class BaseManipulator(BaseRobot):
             if config is not None:
                 self.config = config
                 logger.success(
-                    f"Loaded default config for {self.name}, voltage {voltage}."
+                    f"Loaded default config for {self.name}, voltage {voltage}.\n{self.config.model_dump_json(indent=2)}"
                 )
                 return
 
@@ -1283,9 +1284,6 @@ class BaseManipulator(BaseRobot):
             )
             - close_position
         ) / (open_position - close_position)
-        logger.debug(
-            f"Converting rad {radians} to open command {open_command}. Open position: {open_position}, Close position: {close_position}"
-        )
         return np.clip(open_command, 0, 1)
 
 

--- a/phosphobot/phosphobot/hardware/base.py
+++ b/phosphobot/phosphobot/hardware/base.py
@@ -127,19 +127,25 @@ class BaseManipulator(BaseRobot):
         """
         raise NotImplementedError("The robot enable torque must be implemented.")
 
-    def read_motor_temperature(self, servo_id: int) -> tuple[float,float] | None:
+    def read_motor_temperature(self, servo_id: int) -> tuple[float, float] | None:
         """
         Read the temperature of a motor
         raise: Exception if the routine has not been implemented
         """
-        raise NotImplementedError("The robot read motor temperature must be implemented.")
-    
-    def write__group_motor_maximum_temperature(self, maximum_temperature_target: List[int]) -> None:
+        raise NotImplementedError(
+            "The robot read motor temperature must be implemented."
+        )
+
+    def write_group_motor_maximum_temperature(
+        self, maximum_temperature_target: List[int]
+    ) -> None:
         """
         Write the maximum temperature of all motors of a robot.
         raise: Exception if the routine has not been implemented
         """
-        raise NotImplementedError("The robot write group motor temperature must be implemented.")
+        raise NotImplementedError(
+            "The robot write group motor temperature must be implemented."
+        )
 
     @abstractmethod
     def write_motor_position(self, servo_id: int, units: int, **kwargs) -> None:
@@ -207,9 +213,9 @@ class BaseManipulator(BaseRobot):
 
         # When creating a new robot, you should add default values for these
         # These values depends on the hardware
-        assert self.CALIBRATION_POSITION is not None, (
-            "CALIBRATION_POSITION must be defined in the class"
-        )
+        assert (
+            self.CALIBRATION_POSITION is not None
+        ), "CALIBRATION_POSITION must be defined in the class"
         assert self.RESOLUTION is not None, "RESOLUTION must be defined in the class"
         assert self.SERVO_IDS is not None, "SERVO_IDS must be defined in the class"
 
@@ -1022,6 +1028,7 @@ class BaseManipulator(BaseRobot):
         # )
         # Clamp the command between 0 and 1
         self.update_object_gripping_status()
+
         if not self.is_object_gripped:
             open_command_clipped = np.clip(open_command, 0, 1)
         else:
@@ -1157,7 +1164,7 @@ class BaseManipulator(BaseRobot):
 
         # If the robot is not connected, error raised
         return None
-    
+
     def current_temperature(self) -> List[Temperature] | None:
         """
         Read the current and maximum temperature of the joints of the robot.
@@ -1174,23 +1181,23 @@ class BaseManipulator(BaseRobot):
                     temperature = Temperature(current=temps[0], max=temps[1])
                     temperatures.append(temperature)
                 else:
-                    temperature = Temperature(current=None, max=None)  
+                    temperature = Temperature(current=None, max=None)
                     temperatures.append(temperature)
             return temperatures
-        
+
         # If the robot is not connected, return None
         return None
-    
+
     def set_maximum_temperature(self, maximum_temperature_target: List[int]) -> None:
         """
         Set the maximum temperature of all motors of a robot.
         """
 
         if self.is_connected:
-            self.write__group_motor_maximum_temperature(maximum_temperature_target = maximum_temperature_target)
-        
+            self.write_group_motor_maximum_temperature(
+                maximum_temperature_target=maximum_temperature_target
+            )
 
-    
     def is_powered_on(self) -> bool:
         """
         Return True if all voltage readings are above 0.1V and successful
@@ -1252,10 +1259,34 @@ class BaseManipulator(BaseRobot):
             logger.warning("Robot configuration is not set. Run the calibration first.")
             return
 
+        logger.warning(
+            f"Reading gripper torque: {gripper_torque}. Thresholds: {self.config.gripping_threshold}, {self.config.non_gripping_threshold}"
+        )
         if gripper_torque >= self.config.gripping_threshold:
             self.is_object_gripped = True
         if gripper_torque <= self.config.non_gripping_threshold:
             self.is_object_gripped = False
+
+    def _rad_to_open_command(self, radians: float) -> float:
+        """
+        Convert radians to open command for the gripper.
+        """
+        if self.config is None:
+            raise ValueError(
+                "Robot configuration is not set. Run the calibration first."
+            )
+        open_position = self.config.servos_calibration_position[-1]
+        close_position = self.config.servos_offsets[-1]
+        open_command = (
+            self._radians_to_motor_units(
+                radians=radians, servo_id=self.GRIPPER_JOINT_INDEX
+            )
+            - close_position
+        ) / (open_position - close_position)
+        logger.debug(
+            f"Converting rad {radians} to open command {open_command}. Open position: {open_position}, Close position: {close_position}"
+        )
+        return np.clip(open_command, 0, 1)
 
 
 class BaseMobileRobot(BaseRobot):

--- a/phosphobot/phosphobot/hardware/phosphobot.py
+++ b/phosphobot/phosphobot/hardware/phosphobot.py
@@ -14,6 +14,7 @@ class RemotePhosphobot(BaseRobot):
     """
 
     name = "phosphobot"
+    _config: BaseRobotConfig | None = None
 
     def __init__(self, ip: str, port: int, robot_id: int, **kwargs):
         """

--- a/phosphobot/phosphobot/hardware/so100.py
+++ b/phosphobot/phosphobot/hardware/so100.py
@@ -242,8 +242,9 @@ class SO100Hardware(BaseManipulator):
 
         values = q_target.tolist()
         motor_names = list(self.motors.keys())
+
+        # Gripper is the last parameter of q_target (last motor)
         if not enable_gripper:
-            # Gripper is the last parameter of q_target (last motor)
             values = values[:-1]
             motor_names = motor_names[:-1]
 
@@ -351,9 +352,9 @@ class SO100Hardware(BaseManipulator):
             logger.warning(f"Error reading motor temperature for servo {servo_id}: {e}")
             self.update_motor_errors()
             return None
-    
-    def write__group_motor_maximum_temperature(
-        self, maximum_temperature_target: List[int],  **kwargs
+
+    def write_group_motor_maximum_temperature(
+        self, maximum_temperature_target: List[int], **kwargs
     ) -> None:
         """
         Write the maximum temperature of all motors of a robot.

--- a/phosphobot/phosphobot/leader_follower.py
+++ b/phosphobot/phosphobot/leader_follower.py
@@ -189,7 +189,15 @@ async def leader_follower_loop(
                 leader.write_joint_positions(theta_des_rad, unit="rad")
                 if invert_controls:
                     theta_des_rad[0] = -theta_des_rad[0]
-                follower.write_joint_positions(theta_des_rad, unit="rad")
+                follower.set_motors_positions(
+                    q_target_rad=theta_des_rad, enable_gripper=False
+                )
+                # Get the leader gripper position and set it to the follower
+                follower.control_gripper(
+                    open_command=leader._rad_to_open_command(
+                        theta_des_rad[leader.GRIPPER_JOINT_INDEX]
+                    )
+                )
 
         # Maintain loop frequency
         elapsed = time.perf_counter() - start_time

--- a/phosphobot/phosphobot/leader_follower.py
+++ b/phosphobot/phosphobot/leader_follower.py
@@ -70,12 +70,12 @@ async def leader_follower_loop(
                     )
                     await asyncio.sleep(0.05)
         else:
-            assert isinstance(leader, SO100Hardware), (
-                "Gravity compensation is only supported for SO100Hardware."
-            )
-            assert isinstance(follower, SO100Hardware), (
-                "Gravity compensation is only supported for SO100Hardware."
-            )
+            assert isinstance(
+                leader, SO100Hardware
+            ), "Gravity compensation is only supported for SO100Hardware."
+            assert isinstance(
+                follower, SO100Hardware
+            ), "Gravity compensation is only supported for SO100Hardware."
             leader_current_voltage = leader.current_voltage()
             if (
                 leader_current_voltage is None
@@ -139,14 +139,23 @@ async def leader_follower_loop(
                 # Simple leader-follower control: follower mirrors leader's position
                 if invert_controls:
                     pos_rad[0] = -pos_rad[0]
-                follower.write_joint_positions(list(pos_rad), unit="rad")
+                follower.set_motors_positions(
+                    q_target_rad=pos_rad, enable_gripper=False
+                )
+                # Get the leader gripper position and set it to the follower
+                follower.control_gripper(
+                    open_command=leader._rad_to_open_command(
+                        pos_rad[leader.GRIPPER_JOINT_INDEX]
+                    )
+                )
+
             else:
-                assert isinstance(leader, SO100Hardware), (
-                    "Gravity compensation is only supported for SO100Hardware."
-                )
-                assert isinstance(follower, SO100Hardware), (
-                    "Gravity compensation is only supported for SO100Hardware."
-                )
+                assert isinstance(
+                    leader, SO100Hardware
+                ), "Gravity compensation is only supported for SO100Hardware."
+                assert isinstance(
+                    follower, SO100Hardware
+                ), "Gravity compensation is only supported for SO100Hardware."
                 # Calculate gravity compensation torque
                 # Update PyBullet simulation for gravity calculation
                 for i, idx in enumerate(joint_indices):

--- a/phosphobot/phosphobot/models/__init__.py
+++ b/phosphobot/phosphobot/models/__init__.py
@@ -22,6 +22,7 @@ from .robot import (
     BaseRobotPIDGains,
     RobotConfigStatus,
     Temperature,
+    RobotConfigResponse,
 )
 
 
@@ -372,6 +373,7 @@ class TemperatureReadResponse(BaseModel):
         description=" A list of Temperature objects, one for each joint. If the robot is not connected, this will be None.",
     )
 
+
 class TemperatureWriteRequest(BaseModel):
     """
     Request to set the maximum Temperature for joints of the robot.
@@ -381,7 +383,7 @@ class TemperatureWriteRequest(BaseModel):
         ...,
         description="A list with the maximum temperature of each joint. The length of the list must be equal to the number of joints.",
     )
-    
+
 
 class InfoResponse(BaseModel):
     """
@@ -544,7 +546,7 @@ class RecordingStartRequest(BaseModel):
     )
     enable_rerun_visualization: bool = Field(
         False,
-        description="Enable rerun", 
+        description="Enable rerun",
     )
 
 

--- a/phosphobot/phosphobot/models/robot.py
+++ b/phosphobot/phosphobot/models/robot.py
@@ -262,3 +262,14 @@ class BaseRobotConfig(BaseModel):
         logger.info(f"Saving configuration to {filepath}")
         self.to_json(filepath)
         return filepath
+
+
+class RobotConfigResponse(BaseModel):
+    """
+    Response model for robot configuration.
+    """
+
+    robot_id: int
+    name: str
+    config: BaseRobotConfig | None
+    gripper_joint_index: int | None = None

--- a/phosphobot/phosphobot/models/robot.py
+++ b/phosphobot/phosphobot/models/robot.py
@@ -273,3 +273,5 @@ class RobotConfigResponse(BaseModel):
     name: str
     config: BaseRobotConfig | None
     gripper_joint_index: int | None = None
+    servo_ids: List[int] = Field(default_factory=lambda: list(range(1, 7)))
+    resolution: int = 4096

--- a/phosphobot/phosphobot/models/robot.py
+++ b/phosphobot/phosphobot/models/robot.py
@@ -191,8 +191,16 @@ class BaseRobotConfig(BaseModel):
     pid_gains: List[BaseRobotPIDGains] = Field(default_factory=list)
 
     # Torque value to consider that an object is gripped
-    gripping_threshold: int = 0
-    non_gripping_threshold: int = 0  # noise
+    gripping_threshold: int = Field(
+        default=80,
+        gt=0,
+        description="Torque threshold to consider an object gripped. This will block the gripper position and prevent it from moving further.",
+    )
+    non_gripping_threshold: int = Field(
+        default=10,
+        gt=0,
+        description="Torque threshold to consider an object not gripped. This will allow the gripper to move freely.",
+    )
 
     @classmethod
     def from_json(cls, filepath: str) -> Union["BaseRobotConfig", None]:

--- a/phosphobot/resources/calibration/so-100_12V_config.json
+++ b/phosphobot/resources/calibration/so-100_12V_config.json
@@ -1,62 +1,41 @@
 {
-    "name": "so-100",
-    "servos_voltage": 12.0,
-    "servos_offsets": [
-        2048.0,
-        2048.0,
-        2048.0,
-        2048.0,
-        2048.0,
-        2048.0
-    ],
-    "servos_calibration_position": [
-        1018.0,
-        3177.0,
-        938.0,
-        955.0,
-        3001.0,
-        3489.0
-    ],
-    "servos_offsets_signs": [
-        -1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0
-    ],
-    "pid_gains": [
-        {
-            "p_gain": 16.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        },
-        {
-            "p_gain": 16.0,
-            "i_gain": 0.1,
-            "d_gain": 32.0
-        },
-        {
-            "p_gain": 16.0,
-            "i_gain": 0.1,
-            "d_gain": 32.0
-        },
-        {
-            "p_gain": 16.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        },
-        {
-            "p_gain": 16.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        },
-        {
-            "p_gain": 16.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        }
-    ],
-    "gripping_threshold": 150,
-    "non_gripping_threshold": 10
+  "name": "so-100",
+  "servos_voltage": 12.0,
+  "servos_offsets": [2048.0, 2048.0, 2048.0, 2048.0, 2048.0, 2048.0],
+  "servos_calibration_position": [1018.0, 3177.0, 938.0, 955.0, 3001.0, 3489.0],
+  "servos_offsets_signs": [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+  "pid_gains": [
+    {
+      "p_gain": 16.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    },
+    {
+      "p_gain": 16.0,
+      "i_gain": 0.1,
+      "d_gain": 32.0
+    },
+    {
+      "p_gain": 16.0,
+      "i_gain": 0.1,
+      "d_gain": 32.0
+    },
+    {
+      "p_gain": 16.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    },
+    {
+      "p_gain": 16.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    },
+    {
+      "p_gain": 16.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    }
+  ],
+  "gripping_threshold": 80,
+  "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/calibration/so-100_58CD176683_config.json
+++ b/phosphobot/resources/calibration/so-100_58CD176683_config.json
@@ -1,62 +1,43 @@
 {
-    "name": "so-100",
-    "servos_voltage": 6.0,
-    "servos_offsets": [
-        2045.0,
-        2049.0,
-        2048.0,
-        2048.0,
-        2047.0,
-        2048.0
-    ],
-    "servos_calibration_position": [
-        1067.0,
-        3085.0,
-        1139.0,
-        949.0,
-        3146.0,
-        3274.0
-    ],
-    "servos_offsets_signs": [
-        -1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0
-    ],
-    "pid_gains": [
-        {
-            "p_gain": 12.0,
-            "i_gain": 0.0,
-            "d_gain": 36.0
-        },
-        {
-            "p_gain": 20.0,
-            "i_gain": 0.0,
-            "d_gain": 36.0
-        },
-        {
-            "p_gain": 20.0,
-            "i_gain": 0.0,
-            "d_gain": 36.0
-        },
-        {
-            "p_gain": 20.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        },
-        {
-            "p_gain": 32.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        },
-        {
-            "p_gain": 10.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        }
-    ],
-    "gripping_threshold": 150,
-    "non_gripping_threshold": 10
+  "name": "so-100",
+  "servos_voltage": 6.0,
+  "servos_offsets": [2045.0, 2049.0, 2048.0, 2048.0, 2047.0, 2048.0],
+  "servos_calibration_position": [
+    1067.0, 3085.0, 1139.0, 949.0, 3146.0, 3274.0
+  ],
+  "servos_offsets_signs": [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+  "pid_gains": [
+    {
+      "p_gain": 12.0,
+      "i_gain": 0.0,
+      "d_gain": 36.0
+    },
+    {
+      "p_gain": 20.0,
+      "i_gain": 0.0,
+      "d_gain": 36.0
+    },
+    {
+      "p_gain": 20.0,
+      "i_gain": 0.0,
+      "d_gain": 36.0
+    },
+    {
+      "p_gain": 20.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    },
+    {
+      "p_gain": 32.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    },
+    {
+      "p_gain": 10.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    }
+  ],
+  "gripping_threshold": 80,
+  "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/calibration/so-100_58FA081789_config.json
+++ b/phosphobot/resources/calibration/so-100_58FA081789_config.json
@@ -1,62 +1,43 @@
 {
-    "name": "so-100",
-    "servos_voltage": 6.0,
-    "servos_offsets": [
-        2047.0,
-        2049.0,
-        2048.0,
-        2048.0,
-        2048.0,
-        2048.0
-    ],
-    "servos_calibration_position": [
-        1052.0,
-        3080.0,
-        1112.0,
-        891.0,
-        3117.0,
-        3225.0
-    ],
-    "servos_offsets_signs": [
-        -1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0
-    ],
-    "pid_gains": [
-        {
-            "p_gain": 12.0,
-            "i_gain": 0.0,
-            "d_gain": 36.0
-        },
-        {
-            "p_gain": 20.0,
-            "i_gain": 0.0,
-            "d_gain": 36.0
-        },
-        {
-            "p_gain": 20.0,
-            "i_gain": 0.0,
-            "d_gain": 36.0
-        },
-        {
-            "p_gain": 20.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        },
-        {
-            "p_gain": 32.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        },
-        {
-            "p_gain": 10.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        }
-    ],
-    "gripping_threshold": 150,
-    "non_gripping_threshold": 10
+  "name": "so-100",
+  "servos_voltage": 6.0,
+  "servos_offsets": [2047.0, 2049.0, 2048.0, 2048.0, 2048.0, 2048.0],
+  "servos_calibration_position": [
+    1052.0, 3080.0, 1112.0, 891.0, 3117.0, 3225.0
+  ],
+  "servos_offsets_signs": [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+  "pid_gains": [
+    {
+      "p_gain": 12.0,
+      "i_gain": 0.0,
+      "d_gain": 36.0
+    },
+    {
+      "p_gain": 20.0,
+      "i_gain": 0.0,
+      "d_gain": 36.0
+    },
+    {
+      "p_gain": 20.0,
+      "i_gain": 0.0,
+      "d_gain": 36.0
+    },
+    {
+      "p_gain": 20.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    },
+    {
+      "p_gain": 32.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    },
+    {
+      "p_gain": 10.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    }
+  ],
+  "gripping_threshold": 80,
+  "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/calibration/so-100_58FA082637_config.json
+++ b/phosphobot/resources/calibration/so-100_58FA082637_config.json
@@ -1,62 +1,41 @@
 {
-    "name": "so-100",
-    "servos_voltage": 12.0,
-    "servos_offsets": [
-        1092.0,
-        2929.0,
-        1247.0,
-        1856.0,
-        3695.0,
-        1122.0
-    ],
-    "servos_calibration_position": [
-        -25.0,
-        3927.0,
-        222.0,
-        824.0,
-        4712.0,
-        2238.0
-    ],
-    "servos_offsets_signs": [
-        -1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0
-    ],
-    "pid_gains": [
-        {
-            "p_gain": 6.0,
-            "i_gain": 0.0,
-            "d_gain": 30.0
-        },
-        {
-            "p_gain": 6.0,
-            "i_gain": 0.1,
-            "d_gain": 15.0
-        },
-        {
-            "p_gain": 6.0,
-            "i_gain": 0.1,
-            "d_gain": 15.0
-        },
-        {
-            "p_gain": 10.0,
-            "i_gain": 0.0,
-            "d_gain": 30.0
-        },
-        {
-            "p_gain": 15.0,
-            "i_gain": 0.0,
-            "d_gain": 30.0
-        },
-        {
-            "p_gain": 10.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        }
-    ],
-    "gripping_threshold": 150,
-    "non_gripping_threshold": 10
+  "name": "so-100",
+  "servos_voltage": 12.0,
+  "servos_offsets": [1092.0, 2929.0, 1247.0, 1856.0, 3695.0, 1122.0],
+  "servos_calibration_position": [-25.0, 3927.0, 222.0, 824.0, 4712.0, 2238.0],
+  "servos_offsets_signs": [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+  "pid_gains": [
+    {
+      "p_gain": 6.0,
+      "i_gain": 0.0,
+      "d_gain": 30.0
+    },
+    {
+      "p_gain": 6.0,
+      "i_gain": 0.1,
+      "d_gain": 15.0
+    },
+    {
+      "p_gain": 6.0,
+      "i_gain": 0.1,
+      "d_gain": 15.0
+    },
+    {
+      "p_gain": 10.0,
+      "i_gain": 0.0,
+      "d_gain": 30.0
+    },
+    {
+      "p_gain": 15.0,
+      "i_gain": 0.0,
+      "d_gain": 30.0
+    },
+    {
+      "p_gain": 10.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    }
+  ],
+  "gripping_threshold": 80,
+  "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/calibration/so-100_58FD016236_config.json
+++ b/phosphobot/resources/calibration/so-100_58FD016236_config.json
@@ -1,62 +1,41 @@
 {
-    "name": "so-100",
-    "servos_voltage": 12.0,
-    "servos_offsets": [
-        2051.0,
-        2048.0,
-        2048.0,
-        2048.0,
-        2047.0,
-        2047.0
-    ],
-    "servos_calibration_position": [
-        822.0,
-        3238.0,
-        862.0,
-        1189.0,
-        3074.0,
-        3496.0
-    ],
-    "servos_offsets_signs": [
-        -1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0
-    ],
-    "pid_gains": [
-        {
-            "p_gain": 6.0,
-            "i_gain": 0.0,
-            "d_gain": 30.0
-        },
-        {
-            "p_gain": 6.0,
-            "i_gain": 0.1,
-            "d_gain": 15.0
-        },
-        {
-            "p_gain": 6.0,
-            "i_gain": 0.1,
-            "d_gain": 15.0
-        },
-        {
-            "p_gain": 10.0,
-            "i_gain": 0.0,
-            "d_gain": 30.0
-        },
-        {
-            "p_gain": 15.0,
-            "i_gain": 0.0,
-            "d_gain": 30.0
-        },
-        {
-            "p_gain": 10.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        }
-    ],
-    "gripping_threshold": 100,
-    "non_gripping_threshold": 10
+  "name": "so-100",
+  "servos_voltage": 12.0,
+  "servos_offsets": [2051.0, 2048.0, 2048.0, 2048.0, 2047.0, 2047.0],
+  "servos_calibration_position": [822.0, 3238.0, 862.0, 1189.0, 3074.0, 3496.0],
+  "servos_offsets_signs": [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+  "pid_gains": [
+    {
+      "p_gain": 6.0,
+      "i_gain": 0.0,
+      "d_gain": 30.0
+    },
+    {
+      "p_gain": 6.0,
+      "i_gain": 0.1,
+      "d_gain": 15.0
+    },
+    {
+      "p_gain": 6.0,
+      "i_gain": 0.1,
+      "d_gain": 15.0
+    },
+    {
+      "p_gain": 10.0,
+      "i_gain": 0.0,
+      "d_gain": 30.0
+    },
+    {
+      "p_gain": 15.0,
+      "i_gain": 0.0,
+      "d_gain": 30.0
+    },
+    {
+      "p_gain": 10.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    }
+  ],
+  "gripping_threshold": 80,
+  "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/calibration/so-100_58FD016588_config.json
+++ b/phosphobot/resources/calibration/so-100_58FD016588_config.json
@@ -36,6 +36,6 @@
       "d_gain": 32.0
     }
   ],
-  "gripping_threshold": 150,
+  "gripping_threshold": 80,
   "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/calibration/so-100_58FD017230_config.json
+++ b/phosphobot/resources/calibration/so-100_58FD017230_config.json
@@ -38,6 +38,6 @@
       "d_gain": 32.0
     }
   ],
-  "gripping_threshold": 150,
+  "gripping_threshold": 80,
   "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/calibration/so-100_58FD017238_config.json
+++ b/phosphobot/resources/calibration/so-100_58FD017238_config.json
@@ -1,62 +1,41 @@
 {
-    "name": "so-100",
-    "servos_voltage": 12.0,
-    "servos_offsets": [
-        2113.0,
-        2214.0,
-        1093.0,
-        1938.0,
-        3437.0,
-        800.0
-    ],
-    "servos_calibration_position": [
-        1109.0,
-        3245.0,
-        42.0,
-        926.0,
-        4468.0,
-        1963.0
-    ],
-    "servos_offsets_signs": [
-        -1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0
-    ],
-    "pid_gains": [
-        {
-            "p_gain": 6.0,
-            "i_gain": 0.0,
-            "d_gain": 30.0
-        },
-        {
-            "p_gain": 6.0,
-            "i_gain": 0.1,
-            "d_gain": 15.0
-        },
-        {
-            "p_gain": 6.0,
-            "i_gain": 0.1,
-            "d_gain": 15.0
-        },
-        {
-            "p_gain": 10.0,
-            "i_gain": 0.0,
-            "d_gain": 30.0
-        },
-        {
-            "p_gain": 15.0,
-            "i_gain": 0.0,
-            "d_gain": 30.0
-        },
-        {
-            "p_gain": 10.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        }
-    ],
-    "gripping_threshold": 150,
-    "non_gripping_threshold": 10
+  "name": "so-100",
+  "servos_voltage": 12.0,
+  "servos_offsets": [2113.0, 2214.0, 1093.0, 1938.0, 3437.0, 800.0],
+  "servos_calibration_position": [1109.0, 3245.0, 42.0, 926.0, 4468.0, 1963.0],
+  "servos_offsets_signs": [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+  "pid_gains": [
+    {
+      "p_gain": 6.0,
+      "i_gain": 0.0,
+      "d_gain": 30.0
+    },
+    {
+      "p_gain": 6.0,
+      "i_gain": 0.1,
+      "d_gain": 15.0
+    },
+    {
+      "p_gain": 6.0,
+      "i_gain": 0.1,
+      "d_gain": 15.0
+    },
+    {
+      "p_gain": 10.0,
+      "i_gain": 0.0,
+      "d_gain": 30.0
+    },
+    {
+      "p_gain": 15.0,
+      "i_gain": 0.0,
+      "d_gain": 30.0
+    },
+    {
+      "p_gain": 10.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    }
+  ],
+  "gripping_threshold": 80,
+  "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/calibration/so-100_6V_config.json
+++ b/phosphobot/resources/calibration/so-100_6V_config.json
@@ -1,62 +1,43 @@
 {
-    "name": "so-100",
-    "servos_voltage": 6.0,
-    "servos_offsets": [
-        2048.0,
-        2048.0,
-        2048.0,
-        2048.0,
-        2048.0,
-        2048.0
-    ],
-    "servos_calibration_position": [
-        1072.0,
-        3076.0,
-        979.0,
-        1042.0,
-        2943.0,
-        3422.0
-    ],
-    "servos_offsets_signs": [
-        -1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0
-    ],
-    "pid_gains": [
-        {
-            "p_gain": 12.0,
-            "i_gain": 0.0,
-            "d_gain": 36.0
-        },
-        {
-            "p_gain": 20.0,
-            "i_gain": 0.0,
-            "d_gain": 36.0
-        },
-        {
-            "p_gain": 20.0,
-            "i_gain": 0.0,
-            "d_gain": 36.0
-        },
-        {
-            "p_gain": 20.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        },
-        {
-            "p_gain": 32.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        },
-        {
-            "p_gain": 10.0,
-            "i_gain": 0.0,
-            "d_gain": 32.0
-        }
-    ],
-    "gripping_threshold": 150,
-    "non_gripping_threshold": 10
+  "name": "so-100",
+  "servos_voltage": 6.0,
+  "servos_offsets": [2048.0, 2048.0, 2048.0, 2048.0, 2048.0, 2048.0],
+  "servos_calibration_position": [
+    1072.0, 3076.0, 979.0, 1042.0, 2943.0, 3422.0
+  ],
+  "servos_offsets_signs": [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+  "pid_gains": [
+    {
+      "p_gain": 12.0,
+      "i_gain": 0.0,
+      "d_gain": 36.0
+    },
+    {
+      "p_gain": 20.0,
+      "i_gain": 0.0,
+      "d_gain": 36.0
+    },
+    {
+      "p_gain": 20.0,
+      "i_gain": 0.0,
+      "d_gain": 36.0
+    },
+    {
+      "p_gain": 20.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    },
+    {
+      "p_gain": 32.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    },
+    {
+      "p_gain": 10.0,
+      "i_gain": 0.0,
+      "d_gain": 32.0
+    }
+  ],
+  "gripping_threshold": 80,
+  "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/calibration/wx-250s_FT94W6U7_config.json
+++ b/phosphobot/resources/calibration/wx-250s_FT94W6U7_config.json
@@ -1,70 +1,48 @@
 {
-    "name": "wx-250s",
-    "servos_voltage": 12.0,
-    "servos_offsets": [
-        2059.0,
-        1885.0,
-        2171.0,
-        2075.0,
-        2086.0,
-        2019.0,
-        177.0
-    ],
-    "servos_calibration_position": [
-        3064.0,
-        3079.0,
-        1005.0,
-        3036.0,
-        3050.0,
-        1022.0,
-        1179.0
-    ],
-    "servos_offsets_signs": [
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        1.0,
-        -1.0
-    ],
-    "pid_gains": [
-        {
-            "p_gain": 600.0,
-            "i_gain": 0.0,
-            "d_gain": 200.0
-        },
-        {
-            "p_gain": 600.0,
-            "i_gain": 0.0,
-            "d_gain": 200.0
-        },
-        {
-            "p_gain": 600.0,
-            "i_gain": 0.0,
-            "d_gain": 200.0
-        },
-        {
-            "p_gain": 450.0,
-            "i_gain": 0.0,
-            "d_gain": 200.0
-        },
-        {
-            "p_gain": 450.0,
-            "i_gain": 0.0,
-            "d_gain": 150.0
-        },
-        {
-            "p_gain": 450.0,
-            "i_gain": 0.0,
-            "d_gain": 150.0
-        },
-        {
-            "p_gain": 300.0,
-            "i_gain": 0.0,
-            "d_gain": 100.0
-        }
-    ],
-    "gripping_threshold": 150,
-    "non_gripping_threshold": 20
+  "name": "wx-250s",
+  "servos_voltage": 12.0,
+  "servos_offsets": [2059.0, 1885.0, 2171.0, 2075.0, 2086.0, 2019.0, 177.0],
+  "servos_calibration_position": [
+    3064.0, 3079.0, 1005.0, 3036.0, 3050.0, 1022.0, 1179.0
+  ],
+  "servos_offsets_signs": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, -1.0],
+  "pid_gains": [
+    {
+      "p_gain": 600.0,
+      "i_gain": 0.0,
+      "d_gain": 200.0
+    },
+    {
+      "p_gain": 600.0,
+      "i_gain": 0.0,
+      "d_gain": 200.0
+    },
+    {
+      "p_gain": 600.0,
+      "i_gain": 0.0,
+      "d_gain": 200.0
+    },
+    {
+      "p_gain": 450.0,
+      "i_gain": 0.0,
+      "d_gain": 200.0
+    },
+    {
+      "p_gain": 450.0,
+      "i_gain": 0.0,
+      "d_gain": 150.0
+    },
+    {
+      "p_gain": 450.0,
+      "i_gain": 0.0,
+      "d_gain": 150.0
+    },
+    {
+      "p_gain": 300.0,
+      "i_gain": 0.0,
+      "d_gain": 100.0
+    }
+  ],
+  "gripping_threshold": 80,
+  "non_gripping_threshold": 20
 }

--- a/phosphobot/resources/default/so-100-12V.json
+++ b/phosphobot/resources/default/so-100-12V.json
@@ -1,30 +1,9 @@
 {
   "name": "so-100",
   "servos_voltage": 12.0,
-  "servos_offsets": [
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0
-  ],
-  "servos_calibration_position": [
-    1018.0,
-    3177.0,
-    938.0,
-    955.0,
-    3001.0,
-    3489.0
-  ],
-  "servos_offsets_signs": [
-    -1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
-  ],
+  "servos_offsets": [2048.0, 2048.0, 2048.0, 2048.0, 2048.0, 2048.0],
+  "servos_calibration_position": [1018.0, 3177.0, 938.0, 955.0, 3001.0, 3489.0],
+  "servos_offsets_signs": [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
   "pid_gains": [
     {
       "p_gain": 6.0,
@@ -57,6 +36,6 @@
       "d_gain": 32.0
     }
   ],
-  "gripping_threshold": 150,
+  "gripping_threshold": 80,
   "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/default/so-100-6V.json
+++ b/phosphobot/resources/default/so-100-6V.json
@@ -1,30 +1,11 @@
 {
   "name": "so-100",
   "servos_voltage": 6.0,
-  "servos_offsets": [
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0
-  ],
+  "servos_offsets": [2048.0, 2048.0, 2048.0, 2048.0, 2048.0, 2048.0],
   "servos_calibration_position": [
-    1072.0,
-    3076.0,
-    979.0,
-    1042.0,
-    2943.0,
-    3422.0
+    1072.0, 3076.0, 979.0, 1042.0, 2943.0, 3422.0
   ],
-  "servos_offsets_signs": [
-    -1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
-  ],
+  "servos_offsets_signs": [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
   "pid_gains": [
     {
       "p_gain": 12.0,
@@ -57,6 +38,6 @@
       "d_gain": 32.0
     }
   ],
-  "gripping_threshold": 150,
+  "gripping_threshold": 80,
   "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/default/so-100-leader-12V.json
+++ b/phosphobot/resources/default/so-100-leader-12V.json
@@ -1,30 +1,9 @@
 {
   "name": "so-100",
   "servos_voltage": 12.0,
-  "servos_offsets": [
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0
-  ],
-  "servos_calibration_position": [
-    1018.0,
-    3177.0,
-    938.0,
-    955.0,
-    3001.0,
-    3489.0
-  ],
-  "servos_offsets_signs": [
-    -1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
-  ],
+  "servos_offsets": [2048.0, 2048.0, 2048.0, 2048.0, 2048.0, 2048.0],
+  "servos_calibration_position": [1018.0, 3177.0, 938.0, 955.0, 3001.0, 3489.0],
+  "servos_offsets_signs": [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
   "pid_gains": [
     {
       "p_gain": 6.0,
@@ -57,6 +36,6 @@
       "d_gain": 32.0
     }
   ],
-  "gripping_threshold": 150,
+  "gripping_threshold": 80,
   "non_gripping_threshold": 10
 }

--- a/phosphobot/resources/default/so-100-leader-6V.json
+++ b/phosphobot/resources/default/so-100-leader-6V.json
@@ -1,30 +1,11 @@
 {
   "name": "so-100",
   "servos_voltage": 6.0,
-  "servos_offsets": [
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0,
-    2048.0
-  ],
+  "servos_offsets": [2048.0, 2048.0, 2048.0, 2048.0, 2048.0, 2048.0],
   "servos_calibration_position": [
-    1072.0,
-    3076.0,
-    979.0,
-    1042.0,
-    2943.0,
-    3422.0
+    1072.0, 3076.0, 979.0, 1042.0, 2943.0, 3422.0
   ],
-  "servos_offsets_signs": [
-    -1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0,
-    1.0
-  ],
+  "servos_offsets_signs": [-1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
   "pid_gains": [
     {
       "p_gain": 12.0,
@@ -57,6 +38,6 @@
       "d_gain": 32.0
     }
   ],
-  "gripping_threshold": 150,
+  "gripping_threshold": 80,
   "non_gripping_threshold": 10
 }


### PR DESCRIPTION
This should prevents damages to grippers when doing leader arm control and VR control. This can however lead to the gripper making more objects fall. In this case, simply increase the threshold in the calibration. 