### PR TITLE
Fix BaseRobotConfig validation error for piper arm

### DIFF
--- a/phosphobot/phosphobot/hardware/piper.py
+++ b/phosphobot/phosphobot/hardware/piper.py
@@ -178,7 +178,7 @@ class PiperHardware(BaseManipulator):
             name=self.name,
             servos_voltage=12.0,
             servos_offsets=[0] * len(self.SERVO_IDS),
-            servos_calibration_position=[0] * len(self.SERVO_IDS),
+            servos_calibration_position=[1e-6] * len(self.SERVO_IDS),
             servos_offsets_signs=[1] * len(self.SERVO_IDS),
         )
 
@@ -202,7 +202,7 @@ class PiperHardware(BaseManipulator):
             servos_voltage=12.0,
             servos_offsets=[0] * len(self.SERVO_IDS),
             servos_offsets_signs=[1] * len(self.SERVO_IDS),
-            servos_calibration_position=[0] * len(self.SERVO_IDS),
+            servos_calibration_position=[1e-6] * len(self.SERVO_IDS),
         )
 
     def enable_torque(self) -> None:


### PR DESCRIPTION
I was getting the following error when I tried to connect the Agilex Piper.

`phosphobot.robot:_find_robots:204 - Error connecting to Agilex Piper on can0: 1 validation error for BaseRobotConfigValue error, servos_offsets[0] (0.0) must be different from servos_calibration_position[0] (0.0) [type=value_error, input_value={'name': 'agilex-piper', ...0, 0, 0, 0, 0, 0, 0, 0]}, input_type=dict] `

Fixed by changing 0 in calibration position to a ~0 (1e-6).

### Testing
The error is no longer there and the Phosphobot dashboard shows that the robot is connected. 