### PR TITLE
Add gripper threshold values for piper arm

### DIFF
--- a/phosphobot/phosphobot/hardware/piper.py
+++ b/phosphobot/phosphobot/hardware/piper.py
@@ -180,6 +180,8 @@ class PiperHardware(BaseManipulator):
             servos_offsets=[0] * len(self.SERVO_IDS),
             servos_calibration_position=[0] * len(self.SERVO_IDS),
             servos_offsets_signs=[1] * len(self.SERVO_IDS),
+            gripping_threshold=4500,
+            non_gripping_threshold=500,
         )
 
     def disconnect(self) -> None:


### PR DESCRIPTION
According [piper_sdk](https://github.com/agilexrobotics/piper_sdk/blob/master/asserts/V2/INTERFACE_V2.MD#gripperctrl), gripper torque could vary between 0 to 5000. But the default `BaseRobotConfig` has 10 and 80 as the thresholds requiring to override the values from inside the `piperHardware` class.

`gripper_effort: Gripper torque (0.001 N/m, range 0-5000 corresponds to 0-5 N/m)`

I am not really sure about the exact values to put for the two fields, so going with 4500 and 500 for now.